### PR TITLE
Report timeout after test error

### DIFF
--- a/lib/reporters/error_detail.js
+++ b/lib/reporters/error_detail.js
@@ -59,6 +59,10 @@ ErrorDetail.prototype.done = function() {
     self._stream.write('  ' + errorNumber + ') ' + failure.test.path.join(' ') + ':\n');
     var indentation = errorNumber.toString().length + 4;
 
+    self._errorTracker.getMessages(failure.test).forEach(function(error) {
+      self._stream.write(errorMessageUtil.indent(errorMessageUtil.prettyError(error), indentation) + '\n');
+    });
+
     if (failure.message.result === 'timeout') {
       var lastPhase = self._phaseTracker.getLastPhase(failure.test);
       self._stream.write(errorMessageUtil.indent(errorMessageUtil.prettyTimeout(lastPhase), indentation));
@@ -71,10 +75,6 @@ ErrorDetail.prototype.done = function() {
 
       self._stream.write('\n');
     }
-
-    self._errorTracker.getMessages(failure.test).forEach(function(error) {
-      self._stream.write(errorMessageUtil.indent(errorMessageUtil.prettyError(error), indentation) + '\n');
-    });
   });
 };
 

--- a/test/test_error_detail.js
+++ b/test/test_error_detail.js
@@ -112,6 +112,22 @@ describe('Error detail reporter', function() {
     ]);
   });
 
+  it('should report timeouts after test errors', function() {
+    return doWithReporterAndCheck(function(reporter) {
+      reporter.gotMessage({ path: ['test1'] }, { type: 'startedBeforeHook' });
+      reporter.gotMessage({ path: ['test1'] }, { type: 'error', stack: 'Error: X\n    Trace' });
+      reporter.gotMessage({ path: ['test1'] }, { type: 'finish', result: 'timeout' });
+      reporter.done();
+    }, [
+      /test1:$/,
+      '     Error: X',
+      '       Trace',
+      '',
+      '     In before hook: Timed out',
+      ''
+    ]);
+  });
+
   it('should report the last breadcrumb for tests that time out', function() {
     return doWithReporterAndCheck(function(reporter) {
       reporter.gotMessage({ path: ['test1'] }, { type: 'startedBeforeHook' });


### PR DESCRIPTION
That's the order in which they happen chronologically, so this makes more sense.
