### PR TITLE
Only run Windows builds on node 0.11

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ init:
 
 environment:
   matrix:
-    - nodejs_version: "0.10"
+    # - nodejs_version: "0.10" # Don't run build on 0.10. It takes extra time and error messages are really bad for some reason
     - nodejs_version: "0.11"
 
 install:


### PR DESCRIPTION
They take extra time and for some reason the error messages are worthless on the node 0.10 builds. Ideally, this shouldn't have to be disabled, but let's do it like this for now.

Relates to #49
