### PR TITLE
Make sure stdout/stderr are fully drained before exiting a test

### DIFF
--- a/lib/bin/run_test.js
+++ b/lib/bin/run_test.js
@@ -29,6 +29,7 @@
 'use strict';
 
 var _ = require('lodash');
+var exit = require('exit');  // process.exit that works on Windows
 var fn = require('when/function');
 var when = require('when');
 
@@ -49,7 +50,7 @@ function invokeFunctionNoErrorHandling(fun) {
             stack: 'done callback invoked more than once' +
               (error ? ', failing with: ' + error.stack : ', succeeding')
           });
-          process.exit(1);
+          exit(1);
         }
 
         callbackCalled = true;
@@ -165,15 +166,15 @@ function runTest(suite, testPath) {
       clearInterval(interval);
       // If there are remaining things on the runloop that never finish, we want
       // to exit here, to make sure the test doesn't wait forever.
-      process.exit(0);
+      exit(0);
     }, function() {
-      process.exit(1);
+      exit(1);
     });
 }
 
 process.on('uncaughtException', function(error) {
   sendError(error, { in: 'uncaught' });
-  process.exit(1);
+  exit(1);
 });
 
 var testInterfacePath = process.argv[2];

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "async": "~0.9.0",
     "lodash": "~2.4.1",
     "chalk": "~0.5.1",
-    "teamcity-service-messages": "~0.1.6"
+    "teamcity-service-messages": "~0.1.6",
+    "exit": "~0.1.2"
   },
   "devDependencies": {
     "through": "~2.3.6",


### PR DESCRIPTION
Ugly ugly hack workaround for node bug in Windows.

I don't know how to test this really. There are other tests that actually fail before this fix so I guess it's kindof alright to go without extra tests.

Closes #61
