### PR TITLE
Don't call done when tests are cancelled unless registerTests was called

### DIFF
--- a/lib/reporters/cancellable.js
+++ b/lib/reporters/cancellable.js
@@ -31,6 +31,7 @@ var _ = require('lodash');
 function Cancellable(reporter) {
   this._cancelled = false;
   this._reporter = reporter;
+  this._registerTestsCalled = false;
   this._outstandingTests = {};  // Map from JSON'd test path to true (a set)
 }
 
@@ -40,11 +41,16 @@ Cancellable.prototype._forwardCall = function(message, args) {
   }
 };
 
-['registrationFailed', 'registerTests', 'done'].forEach(function(message) {
+['registrationFailed', 'done'].forEach(function(message) {
   Cancellable.prototype[message] = function() {
     this._forwardCall(message, arguments);
   };
 });
+
+Cancellable.prototype.registerTests = function() {
+  this._registerTestsCalled = true;
+  this._forwardCall('registerTests', arguments);
+};
 
 Cancellable.prototype.gotMessage = function(testPath, message) {
   var key = JSON.stringify(testPath);
@@ -69,7 +75,7 @@ Cancellable.prototype.cancel = function() {
     });
   }
 
-  if (this._reporter.done) {
+  if (this._registerTestsCalled && this._reporter.done) {
     this._reporter.done();
   }
 };

--- a/test/test_cancellable.js
+++ b/test/test_cancellable.js
@@ -61,6 +61,7 @@ describe('Cancellable reporter', function() {
           }
         }
       });
+      cancellable.registerTests(['test1', 'test2']);
       cancellable.gotMessage('test1', { type: 'start' });
       cancellable.cancel();
       cancellable.done();
@@ -79,11 +80,21 @@ describe('Cancellable reporter', function() {
           }
         }
       });
+      cancellable.registerTests(['test1', 'test2']);
       cancellable.gotMessage('test1', { type: 'start' });
       cancellable.gotMessage('test2', { type: 'start' });
       cancellable.gotMessage('test1', { type: 'finish' });
       cancellable.cancel();
       cancellable.done();
+    });
+
+    it('should not invoke done unless registerTests has been called', function() {
+      var cancellable = new Cancellable({
+        done: function() {
+          throw new Error('should not be called');
+        }
+      });
+      cancellable.cancel();
     });
   });
 });


### PR DESCRIPTION
Otherwise the Reporter API is violated. `done` should only be called after `registerTests`.

This would manifest as a crash in the suite runner if it was cancelled while gathering the list of tests to run.
