### PR TITLE
DRAFT Proposal: Parallelism default based on cpus

### DIFF
--- a/doc/suite_runner_api.md
+++ b/doc/suite_runner_api.md
@@ -47,7 +47,7 @@ runner:
   by default.
 * `attempts`: Maximum number of times to run a test; if >1 the test will be
   retried on failure. Defaults to 1.
-* `parallelism`: Number of tests to run in parallel. Defaults to 8.
+* `parallelism`: Number of tests to run in parallel. Defaults to `Math.floor(numberOfCpus * 1.5)`.
 * `grep`: Regex or string. Only tests that match the criteria will be run.
 * `invertGrep`: If true, the criteria given to `grep` is inverted.
 * `disallowOnly`: Fail if there are tests marked as only. This may be useful to


### PR DESCRIPTION
Wondering if this should be based on cpus rather than constant value
