### PR TITLE
Enrich output to TeamCity in case of test timeout

### DIFF
--- a/lib/reporters/teamcity.js
+++ b/lib/reporters/teamcity.js
@@ -20,6 +20,9 @@ var _ = require('lodash');
 var teamcityServiceMessages = require('teamcity-service-messages');
 var Serializer = require('./serializer');
 var SuiteMarker = require('./suite_marker');
+var errorMessageUtil = require('../error_message_util');
+var MessageTracker = require('./message_tracker');
+var PhaseTracker = require('./phase_tracker');
 
 teamcityServiceMessages.stdout = false;  // Global yuck :-(
 
@@ -34,6 +37,9 @@ function Teamcity(stream) {
   this._stream = stream;
   this._emittedErrorForTest = {};  // Keys are JSON testPath, value is true if an error has been emitted for that test
   this._bufferedOutput = {};  // Keys are JSON testPath, value is output for the test
+  this._errorTracker = new MessageTracker('error');
+  this._breadcrumbTracker = new MessageTracker('breadcrumb');
+  this._phaseTracker = new PhaseTracker();
 }
 
 Teamcity.prototype.registrationFailed = function(error) {
@@ -82,6 +88,10 @@ Teamcity.prototype.gotMessage = function(testPath, message) {
   var testName = testPath && _.last(testPath.path);
   var suiteName = message.suite && message.suite.path.join(' ');
 
+  this._phaseTracker.gotMessage(testPath, message);
+  this._errorTracker.gotMessage(testPath, message);
+  this._breadcrumbTracker.gotMessage(testPath, message);
+
   if (message.type === 'stdout') {
     // ##teamcity[testStdOut name='testname' out='text']
     this._bufferTestOutput(testPath, teamcityServiceMessages.testStdOut({
@@ -106,7 +116,30 @@ Teamcity.prototype.gotMessage = function(testPath, message) {
     }
   } else if (message.type === 'timeout') {
     // ##teamcity[testFailed name='test1' message='Test timed out' details='message and stack trace']
-    this._emitErrorForTest(testPath, { name: testName, message: 'Test timed out' });
+
+    var indentation = 0;
+    var msgs = [];
+
+    var errors = this._errorTracker.getMessages(testPath);
+    errors.forEach(function(error) {
+      msgs.push(errorMessageUtil.indent(errorMessageUtil.prettyError(error), indentation) + '\n');
+    });
+
+    var lastPhase = this._phaseTracker.getLastPhase(testPath);
+    msgs.push(errorMessageUtil.indent(errorMessageUtil.prettyTimeout(lastPhase), indentation));
+
+    var breadcrumb = _.last(this._breadcrumbTracker.getMessages(testPath));
+    if (breadcrumb) {
+      var breadcrumbString = errorMessageUtil.prettyBreadcrumb(breadcrumb, 'Last breadcrumb');
+      msgs.push(errorMessageUtil.indent(breadcrumbString, indentation));
+    }
+
+    var timeoutMessage = {
+      name: testName,
+      message: 'Timed out: ' + (breadcrumb ? breadcrumb.message : 'missing breadcrumb'),
+      details: msgs.join('\n')
+    };
+    this._emitErrorForTest(testPath, timeoutMessage);
   } else if (message.type === 'error') {
     // possibly: ##teamcity[testFailed name='test1' message='failure message' details='message and stack trace']
     // possibly: ##teamcity[testFailed type='comparisonFailure' name='test2' message='failure message' details='message and stack trace' expected='expected value' actual='actual value']

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "overman",
-  "version": "0.8.7",
+  "version": "0.9.0",
   "description": "Test runner for integration tests",
   "main": "lib/overman.js",
   "scripts": {

--- a/test/test_teamcity.js
+++ b/test/test_teamcity.js
@@ -271,7 +271,7 @@ describe('TeamCity reporter', function() {
         reporter.gotMessage(path, { type: 'finish', result: 'failure' });
       }, [
         /testStarted/,
-        /##teamcity\[testFailed name='test1' message='Test timed out' flowId='\d+' timestamp='....-..-..T..:..:..\....'\]/,
+        /##teamcity\[testFailed name='test1' message='Timed out: [^\']+' details='[^\']+' flowId='\d+' timestamp='....-..-..T..:..:..\....'\]/,
         /testFinished/
       ]);
     });
@@ -384,7 +384,7 @@ describe('TeamCity reporter', function() {
         reporter.gotMessage(path, { type: 'finish', result: 'timeout' });
       }, [
         /testStarted/,
-        /##teamcity\[testFailed name='test1' message='Test timed out' flowId='\d+' timestamp='....-..-..T..:..:..\....'\]/,
+        /##teamcity\[testFailed name='test1' message='Timed out: [^\']+' details='[^\']+' flowId='\d+' timestamp='....-..-..T..:..:..\....'\]/,
         /##teamcity\[testFinished name='test1' flowId='\d+' timestamp='....-..-..T..:..:..\....'\]/
       ]);
     });


### PR DESCRIPTION
Current TeamCity output looks just like `Test timed out` with no details even in the build log.

This PR makes output more verbose, allowing to understand the test failure better just looking at the TeamCity output.

Testing done: local run of the test suite emulating TeamCity run.
Output looks like this:

```
##teamcity[testFailed name='some test name' message='Timed out: expected |'one thing|' to equal |'another thing|'' details='In test: Timed out|n|nLast breadcrumb: expected |'one thing|' to equal |'another thing|'|n  at Assertion.assertEqual (/path/to/chai/lib/chai/core/assertions.js:487:12)|n  at Assertion.ctx.(anonymous function) |[as equal|] /path/to/chai/lib/chai/utils/addMethod.js:41:25)|n  at /path/to/tests/my_tests.js:114:43|n' flowId='1234567890' timestamp='2019-05-16T14:09:11.169']
```