### PR TITLE
MessageTracker: don't clear _messages on retry

### DIFF
--- a/src/reporters/message_tracker.js
+++ b/src/reporters/message_tracker.js
@@ -60,7 +60,6 @@ MessageTracker.prototype.gotMessage = function(testPath, message) {
   } else if (message.type === 'timeout') {
     this._timedout[testPathToKey(testPath)] = true;
   } else if (message.type === 'retry') {
-    this._messages[testPathToKey(testPath)] = [];
     delete this._timedout[testPathToKey(testPath)];
   }
 };


### PR DESCRIPTION
When running multiple attempts, messages that only get sent before `retry` (e.g. `attributes`) get purged even if a later attempt succeeds.