### PR TITLE
soft_kill: handle process 'error' before sending signal over IPC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "overman",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "overman",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "async": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "overman",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Test runner for integration tests",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/soft_kill.ts
+++ b/src/soft_kill.ts
@@ -26,9 +26,7 @@ export default function softKill(
   timeout: number,
   timerFactory?: (timeout: number) => Timer
 ) {
-  if (!process.connected) {
-    return;
-  } else if (timeout === 0) {
+  if (timeout === 0) {
     process.kill('SIGKILL');
     return;
   }
@@ -37,15 +35,12 @@ export default function softKill(
   timer.on('timeout', () => process.kill('SIGKILL'));
 
   process.on('exit', () => timer.cancel());
+  // Catch any error that may occur as a result of killing the process.
+  process.on('error', () => {});
   // Instead of sending a real SIGINT, try to send a message to the sub-process
   // and let it treat it as if it received a SIGINT. SIGINT doesn't exist on
-  // Windows. The process connected property doesn't seem to be a guarantee
-  // against EPIPE.
-  try {
-    process.send({ type: 'sigint' });
-  } catch (e) {
-    // Ignored. The timeout will trigger a SIGKILL instead.
-  }
+  // Windows.
+  process.send({ type: 'sigint' });
 }
 
 export type SoftKill = typeof softKill;


### PR DESCRIPTION
Remove the 2 previous (ineffective) attempts to fix the `EPIPE` issue. This is not well documented, so it's a guess that when the Error happens asynchronously, it either goes via an error handler (if any attached) or thrown in which case it ends up uncaught.